### PR TITLE
Remove Unwraps from the lib, minor changes to api that returns results now

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["web-programming", "api-bindings"]
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0.28"
+anyhow = "1.0"
 base64 = "0.12"
 lazy_static = "1.4"
 log = "0.4"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ let contact = vec!["mailto:foo@bar.com".to_string()];
 let acc = dir.register_account(contact.clone())?;
 
 // Example of how to load an account from string:
-let privkey = acc.acme_private_key_pem();
+let privkey = acc.acme_private_key_pem()?;
 let acc = dir.load_account(&privkey, contact)?;
 
 // Order a new TLS certificate for a domain.
@@ -57,14 +57,14 @@ let ord_csr = loop {
     // certificate for:
     //
     // http://mydomain.io/.well-known/acme-challenge/<token>
-    let chall = auths[0].http_challenge();
+    let chall = auths[0].http_challenge().unwrap();
 
     // The token is the filename.
     let token = chall.http_token();
     let path = format!(".well-known/acme-challenge/{}", token);
 
     // The proof is the contents of the file
-    let proof = chall.http_proof();
+    let proof = chall.http_proof()?;
 
     // Here you must do "something" to place
     // the file/contents in the correct place.
@@ -87,7 +87,7 @@ let ord_csr = loop {
 // Ownership is proven. Create a private key for
 // the certificate. These are provided for convenience, you
 // can provide your own keypair instead if you want.
-let pkey_pri = create_p384_key();
+let pkey_pri = create_p384_key()?;
 
 // Submit the CSR. This causes the ACME provider to enter a
 // state of "processing" that must be polled until the

--- a/src/acc/akey.rs
+++ b/src/acc/akey.rs
@@ -12,14 +12,13 @@ pub(crate) struct AcmeKey {
 }
 
 impl AcmeKey {
-    pub(crate) fn new() -> AcmeKey {
-        let pri_key = EcKey::generate(&*EC_GROUP_P256).expect("EcKey");
-        Self::from_key(pri_key)
+    pub(crate) fn new() -> Result<AcmeKey> {
+        let pri_key = EcKey::generate(&*EC_GROUP_P256).context("EcKey")?;
+        Ok(Self::from_key(pri_key))
     }
 
     pub(crate) fn from_pem(pem: &[u8]) -> Result<AcmeKey> {
-        let pri_key = EcKey::private_key_from_pem(pem)
-            .context("Failed to read PEM")?;
+        let pri_key = EcKey::private_key_from_pem(pem).context("Failed to read PEM")?;
         Ok(Self::from_key(pri_key))
     }
 
@@ -30,10 +29,12 @@ impl AcmeKey {
         }
     }
 
-    pub(crate) fn to_pem(&self) -> Vec<u8> {
-        self.private_key
+    pub(crate) fn to_pem(&self) -> Result<Vec<u8>> {
+        let pem = self
+            .private_key
             .private_key_to_pem()
-            .expect("private_key_to_pem")
+            .context("private_key_to_pem")?;
+        Ok(pem)
     }
 
     pub(crate) fn private_key(&self) -> &EcKey<pkey::Private> {

--- a/src/acc/mod.rs
+++ b/src/acc/mod.rs
@@ -57,8 +57,9 @@ impl Account {
     /// Private key for this account.
     ///
     /// The key is an elliptic curve private key.
-    pub fn acme_private_key_pem(&self) -> String {
-        String::from_utf8(self.inner.transport.acme_key().to_pem()).expect("from_utf8")
+    pub fn acme_private_key_pem(&self) -> Result<String> {
+        let pem = String::from_utf8(self.inner.transport.acme_key().to_pem()?)?;
+        Ok(pem)
     }
 
     /// Create a new order to issue a certificate for this account.
@@ -100,7 +101,7 @@ impl Account {
     /// Revoke a certificate for the reason given.
     pub fn revoke_certificate(&self, cert: &Certificate, reason: RevocationReason) -> Result<()> {
         // convert to base64url of the DER (which is not PEM).
-        let certificate = base64url(&cert.certificate_der());
+        let certificate = base64url(&cert.certificate_der()?);
 
         let revoc = ApiRevocation {
             certificate,
@@ -145,9 +146,7 @@ mod test {
         let server = crate::test::with_directory_server();
         let url = DirectoryUrl::Other(&server.dir_url);
         let dir = Directory::from_url(url)?;
-        let acc = dir.register_account(vec![
-            "mailto:foo@bar.com".to_string(),
-        ])?;
+        let acc = dir.register_account(vec!["mailto:foo@bar.com".to_string()])?;
         let _ = acc.new_order("acmetest.example.com", &[])?;
         Ok(())
     }

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -1,12 +1,14 @@
+use crate::error::Result;
 use lazy_static::lazy_static;
-use openssl::ec::{Asn1Flag, EcGroup, EcKey};
-use openssl::hash::MessageDigest;
-use openssl::nid::Nid;
-use openssl::pkey::{self, PKey};
-use openssl::rsa::Rsa;
-use openssl::stack::Stack;
-use openssl::x509::extension::SubjectAlternativeName;
-use openssl::x509::{X509Req, X509ReqBuilder, X509};
+use openssl::{
+    ec::{Asn1Flag, EcGroup, EcKey},
+    hash::MessageDigest,
+    nid::Nid,
+    pkey::{self, PKey},
+    rsa::Rsa,
+    stack::Stack,
+    x509::{extension::SubjectAlternativeName, X509Req, X509ReqBuilder, X509},
+};
 
 use crate::error::*;
 
@@ -26,33 +28,36 @@ fn ec_group(nid: Nid) -> EcGroup {
 ///
 /// This library does not check the number of bits used to create the key pair.
 /// For Let's Encrypt, the bits must be between 2048 and 4096.
-pub fn create_rsa_key(bits: u32) -> PKey<pkey::Private> {
-    let pri_key_rsa = Rsa::generate(bits).expect("Rsa::generate");
-    PKey::from_rsa(pri_key_rsa).expect("from_rsa")
+pub fn create_rsa_key(bits: u32) -> Result<PKey<pkey::Private>> {
+    let pri_key_rsa = Rsa::generate(bits)?;
+    let pkey = PKey::from_rsa(pri_key_rsa)?;
+    Ok(pkey)
 }
 
 /// Make a P-256 private key (from which we can derive a public key).
-pub fn create_p256_key() -> PKey<pkey::Private> {
-    let pri_key_ec = EcKey::generate(&*EC_GROUP_P256).expect("EcKey");
-    PKey::from_ec_key(pri_key_ec).expect("from_ec_key")
+pub fn create_p256_key() -> Result<PKey<pkey::Private>> {
+    let pri_key_ec = EcKey::generate(&*EC_GROUP_P256)?;
+    let pkey = PKey::from_ec_key(pri_key_ec)?;
+    Ok(pkey)
 }
 
 /// Make a P-384 private key pair (from which we can derive a public key).
-pub fn create_p384_key() -> PKey<pkey::Private> {
-    let pri_key_ec = EcKey::generate(&*EC_GROUP_P384).expect("EcKey");
-    PKey::from_ec_key(pri_key_ec).expect("from_ec_key")
+pub fn create_p384_key() -> Result<PKey<pkey::Private>> {
+    let pri_key_ec = EcKey::generate(&*EC_GROUP_P384)?;
+    let pkey = PKey::from_ec_key(pri_key_ec)?;
+    Ok(pkey)
 }
 
 pub(crate) fn create_csr(pkey: &PKey<pkey::Private>, domains: &[&str]) -> Result<X509Req> {
     //
     // the csr builder
-    let mut req_bld = X509ReqBuilder::new().expect("X509ReqBuilder");
+    let mut req_bld = X509ReqBuilder::new()?;
 
     // set private/public key in builder
-    req_bld.set_pubkey(&pkey).expect("set_pubkey");
+    req_bld.set_pubkey(&pkey)?;
 
     // set all domains as alt names
-    let mut stack = Stack::new().expect("Stack::new");
+    let mut stack = Stack::new()?;
     let ctx = req_bld.x509v3_context(None);
     let as_lst = domains
         .iter()
@@ -62,14 +67,12 @@ pub(crate) fn create_csr(pkey: &PKey<pkey::Private>, domains: &[&str]) -> Result
     let as_lst = as_lst[4..].to_string();
     let mut an = SubjectAlternativeName::new();
     an.dns(&as_lst);
-    let ext = an.build(&ctx).expect("SubjectAlternativeName::build");
+    let ext = an.build(&ctx)?;
     stack.push(ext).expect("Stack::push");
-    req_bld.add_extensions(&stack).expect("add_extensions");
+    req_bld.add_extensions(&stack)?;
 
     // sign it
-    req_bld
-        .sign(pkey, MessageDigest::sha256())
-        .expect("csr_sign");
+    req_bld.sign(pkey, MessageDigest::sha256())?;
 
     // the csr
     Ok(req_bld.build())
@@ -108,9 +111,10 @@ impl Certificate {
     }
 
     /// The private key as DER.
-    pub fn private_key_der(&self) -> Vec<u8> {
-        let pkey = PKey::private_key_from_pem(self.private_key.as_bytes()).expect("from_pem");
-        pkey.private_key_to_der().expect("private_key_to_der")
+    pub fn private_key_der(&self) -> Result<Vec<u8>> {
+        let pkey = PKey::private_key_from_pem(self.private_key.as_bytes())?;
+        let der = pkey.private_key_to_der()?;
+        Ok(der)
     }
 
     /// The PEM encoded issued certificate.
@@ -119,9 +123,10 @@ impl Certificate {
     }
 
     /// The issued certificate as DER.
-    pub fn certificate_der(&self) -> Vec<u8> {
-        let x509 = X509::from_pem(self.certificate.as_bytes()).expect("from_pem");
-        x509.to_der().expect("to_der")
+    pub fn certificate_der(&self) -> Result<Vec<u8>> {
+        let x509 = X509::from_pem(self.certificate.as_bytes())?;
+        let der = x509.to_der()?;
+        Ok(der)
     }
 
     /// Inspect the certificate to count the number of (whole) valid days left.
@@ -131,29 +136,30 @@ impl Certificate {
     /// issued cert, since it counts _whole_ days.
     ///
     /// It is possible to get negative days for an expired certificate.
-    pub fn valid_days_left(&self) -> i64 {
+    pub fn valid_days_left(&self) -> Result<i64> {
         // the cert used in the tests is not valid to load as x509
         if cfg!(test) {
-            return 89;
+            return Ok(89);
         }
 
         // load as x509
-        let x509 = X509::from_pem(self.certificate.as_bytes()).expect("from_pem");
+        let x509 = X509::from_pem(self.certificate.as_bytes())?;
 
         // convert asn1 time to Tm
         let not_after = format!("{}", x509.not_after());
         // Display trait produces this format, which is kinda dumb.
         // Apr 19 08:48:46 2019 GMT
-        let expires = parse_date(&not_after);
+        let expires = parse_date(&not_after)?;
         let dur = expires - time::now();
 
-        dur.num_days()
+        Ok(dur.num_days())
     }
 }
 
-fn parse_date(s: &str) -> time::Tm {
+fn parse_date(s: &str) -> Result<time::Tm> {
     debug!("Parse date/time: {}", s);
-    time::strptime(s, "%h %e %H:%M:%S %Y %Z").expect("strptime")
+    let tm = time::strptime(s, "%h %e %H:%M:%S %Y %Z")?;
+    Ok(tm)
 }
 
 #[cfg(test)]
@@ -162,7 +168,7 @@ mod test {
 
     #[test]
     fn test_parse_date() {
-        let x = parse_date("May  3 07:40:15 2019 GMT");
+        let x = parse_date("May  3 07:40:15 2019 GMT").unwrap();
         assert_eq!(time::strftime("%F %T", &x).unwrap(), "2019-05-03 07:40:15");
     }
 }

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -1,13 +1,15 @@
 //
 use std::sync::Arc;
 
-use crate::acc::AcmeKey;
-use crate::api::{ApiAccount, ApiDirectory};
-use crate::error::*;
-use crate::req::{req_expect_header, req_get, req_handle_error};
-use crate::trans::{NoncePool, Transport};
-use crate::util::read_json;
-use crate::Account;
+use crate::{
+    acc::AcmeKey,
+    api::{ApiAccount, ApiDirectory},
+    error::*,
+    req::{req_expect_header, req_get, req_handle_error},
+    trans::{NoncePool, Transport},
+    util::read_json,
+    Account,
+};
 
 const LETSENCRYPT: &str = "https://acme-v02.api.letsencrypt.org/directory";
 const LETSENCRYPT_STAGING: &str = "https://acme-staging-v02.api.letsencrypt.org/directory";
@@ -56,7 +58,7 @@ impl Directory {
     }
 
     pub fn register_account(&self, contact: Vec<String>) -> Result<Account> {
-        let acme_key = AcmeKey::new();
+        let acme_key = AcmeKey::new()?;
         self.upsert_account(acme_key, contact)
     }
 
@@ -115,9 +117,7 @@ mod test {
         let server = crate::test::with_directory_server();
         let url = DirectoryUrl::Other(&server.dir_url);
         let dir = Directory::from_url(url)?;
-        let _ = dir.register_account(vec![
-            "mailto:foo@bar.com".to_string(),
-        ])?;
+        let _ = dir.register_account(vec!["mailto:foo@bar.com".to_string()])?;
         Ok(())
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
-pub use anyhow::{Error, Result, Context, anyhow, bail};
-pub use log::{debug, trace};
 use crate::api::ApiProblem;
+pub use anyhow::{anyhow, bail, Context, Error, Result};
+pub use log::{debug, trace};
 
 impl From<ApiProblem> for Error {
     fn from(x: ApiProblem) -> Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //! let acc = dir.register_account(contact.clone())?;
 //!
 //! // Example of how to load an account from string:
-//! let privkey = acc.acme_private_key_pem().unwrap();
+//! let privkey = acc.acme_private_key_pem()?;
 //! let acc = dir.load_account(&privkey, contact)?;
 //!
 //! // Order a new TLS certificate for a domain.
@@ -62,7 +62,7 @@
 //!     let path = format!(".well-known/acme-challenge/{}", token);
 //!
 //!     // The proof is the contents of the file
-//!     let proof = chall.http_proof().unwrap();
+//!     let proof = chall.http_proof()?;
 //!
 //!     // Here you must do "something" to place
 //!     // the file/contents in the correct place.
@@ -85,7 +85,7 @@
 //! // Ownership is proven. Create a private key for
 //! // the certificate. These are provided for convenience, you
 //! // can provide your own keypair instead if you want.
-//! let pkey_pri = create_p384_key().unwrap();
+//! let pkey_pri = create_p384_key()?;
 //!
 //! // Submit the CSR. This causes the ACME provider to enter a
 //! // state of "processing" that must be polled until the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //! let acc = dir.register_account(contact.clone())?;
 //!
 //! // Example of how to load an account from string:
-//! let privkey = acc.acme_private_key_pem();
+//! let privkey = acc.acme_private_key_pem().unwrap();
 //! let acc = dir.load_account(&privkey, contact)?;
 //!
 //! // Order a new TLS certificate for a domain.
@@ -55,14 +55,14 @@
 //!     // certificate for:
 //!     //
 //!     // http://mydomain.io/.well-known/acme-challenge/<token>
-//!     let chall = auths[0].http_challenge();
+//!     let chall = auths[0].http_challenge().unwrap();
 //!
 //!     // The token is the filename.
 //!     let token = chall.http_token();
 //!     let path = format!(".well-known/acme-challenge/{}", token);
 //!
 //!     // The proof is the contents of the file
-//!     let proof = chall.http_proof();
+//!     let proof = chall.http_proof().unwrap();
 //!
 //!     // Here you must do "something" to place
 //!     // the file/contents in the correct place.
@@ -85,7 +85,7 @@
 //! // Ownership is proven. Create a private key for
 //! // the certificate. These are provided for convenience, you
 //! // can provide your own keypair instead if you want.
-//! let pkey_pri = create_p384_key();
+//! let pkey_pri = create_p384_key().unwrap();
 //!
 //! // Submit the CSR. This causes the ACME provider to enter a
 //! // state of "processing" that must be polled until the

--- a/src/order/auth.rs
+++ b/src/order/auth.rs
@@ -78,7 +78,7 @@ impl Auth {
     ///     format!("/var/www/.well-known/acme-challenge/{}", token)
     ///   };
     ///   let mut file = File::create(&path)?;
-    ///   file.write_all(challenge.http_proof().unwrap().as_bytes())?;
+    ///   file.write_all(challenge.http_proof()?.as_bytes())?;
     ///   challenge.validate(5000)?;
     ///   Ok(())
     /// }

--- a/src/order/auth.rs
+++ b/src/order/auth.rs
@@ -2,7 +2,7 @@
 use openssl::sha::sha256;
 use std::sync::Arc;
 use std::thread;
-use std::time::Duration;
+use std::{convert::TryInto, time::Duration};
 
 use crate::acc::AccountInner;
 use crate::acc::AcmeKey;
@@ -71,23 +71,22 @@ impl Auth {
     /// use std::io::Write;
     ///
     /// fn web_authorize(auth: &Auth) -> Result<(), Error> {
-    ///   let challenge = auth.http_challenge();
+    ///   let challenge = auth.http_challenge().unwrap();
     ///   // Assuming our web server's root is under /var/www
     ///   let path = {
     ///     let token = challenge.http_token();
     ///     format!("/var/www/.well-known/acme-challenge/{}", token)
     ///   };
     ///   let mut file = File::create(&path)?;
-    ///   file.write_all(challenge.http_proof().as_bytes())?;
+    ///   file.write_all(challenge.http_proof().unwrap().as_bytes())?;
     ///   challenge.validate(5000)?;
     ///   Ok(())
     /// }
     /// ```
-    pub fn http_challenge(&self) -> Challenge<Http> {
+    pub fn http_challenge(&self) -> Option<Challenge<Http>> {
         self.api_auth
             .http_challenge()
             .map(|c| Challenge::new(&self.inner, c.clone(), &self.auth_url))
-            .expect("http-challenge")
     }
 
     /// Get the dns challenge.
@@ -105,7 +104,7 @@ impl Auth {
     /// use acme_micro::Error;
     ///
     /// fn dns_authorize(auth: &Auth) -> Result<(), Error> {
-    ///   let challenge = auth.dns_challenge();
+    ///   let challenge = auth.dns_challenge().unwrap();
     ///   let record = format!("_acme-challenge.{}.", auth.domain_name());
     ///   // route_53_set_record(&record, "TXT", challenge.dns_proof());
     ///   challenge.validate(5000)?;
@@ -114,11 +113,10 @@ impl Auth {
     /// ```
     ///
     /// The dns proof is not the same as the http proof.
-    pub fn dns_challenge(&self) -> Challenge<Dns> {
+    pub fn dns_challenge(&self) -> Option<Challenge<Dns>> {
         self.api_auth
             .dns_challenge()
             .map(|c| Challenge::new(&self.inner, c.clone(), &self.auth_url))
-            .expect("dns-challenge")
     }
 
     /// Get the TLS ALPN challenge.
@@ -128,11 +126,10 @@ impl Auth {
     /// must contain a single dNSName SAN containing the domain being
     /// validated, as well as an ACME extension containing the SHA256 of the
     /// key authorization.
-    pub fn tls_alpn_challenge(&self) -> Challenge<TlsAlpn> {
+    pub fn tls_alpn_challenge(&self) -> Option<Challenge<TlsAlpn>> {
         self.api_auth
             .tls_alpn_challenge()
             .map(|c| Challenge::new(&self.inner, c.clone(), &self.auth_url))
-            .expect("tls-alpn-challenge")
     }
 
     /// Access the underlying JSON object for debugging. We don't
@@ -177,9 +174,10 @@ impl Challenge<Http> {
     }
 
     /// The `proof` is some text content that is placed in the file named by `token`.
-    pub fn http_proof(&self) -> String {
+    pub fn http_proof(&self) -> Result<String> {
         let acme_key = self.inner.transport.acme_key();
-        key_authorization(&self.api_challenge.token, acme_key, false)
+        let proof = key_authorization(&self.api_challenge.token, acme_key, false)?;
+        Ok(proof)
     }
 }
 
@@ -189,18 +187,20 @@ impl Challenge<Dns> {
     /// ```text
     /// _acme-challenge.<domain-to-be-proven>.  TXT  <proof>
     /// ```
-    pub fn dns_proof(&self) -> String {
+    pub fn dns_proof(&self) -> Result<String> {
         let acme_key = self.inner.transport.acme_key();
-        key_authorization(&self.api_challenge.token, acme_key, true)
+        let proof = key_authorization(&self.api_challenge.token, acme_key, true)?;
+        Ok(proof)
     }
 }
 
 impl Challenge<TlsAlpn> {
     /// The `proof` is the contents of the ACME extension to be placed in the
     /// certificate used for validation.
-    pub fn tls_alpn_proof(&self) -> [u8; 32] {
+    pub fn tls_alpn_proof(&self) -> Result<[u8; 32]> {
         let acme_key = self.inner.transport.acme_key();
-        sha256(key_authorization(&self.api_challenge.token, acme_key, false).as_bytes())
+        let proof = key_authorization(&self.api_challenge.token, acme_key, false)?;
+        Ok(sha256(proof.as_bytes()))
     }
 }
 
@@ -257,17 +257,18 @@ impl<A> Challenge<A> {
     }
 }
 
-fn key_authorization(token: &str, key: &AcmeKey, extra_sha256: bool) -> String {
-    let jwk: Jwk = key.into();
+fn key_authorization(token: &str, key: &AcmeKey, extra_sha256: bool) -> Result<String> {
+    let jwk: Jwk = key.try_into()?;
     let jwk_thumb: JwkThumb = (&jwk).into();
-    let jwk_json = serde_json::to_string(&jwk_thumb).expect("jwk_thumb");
+    let jwk_json = serde_json::to_string(&jwk_thumb)?;
     let digest = base64url(&sha256(jwk_json.as_bytes()));
     let key_auth = format!("{}.{}", token, digest);
-    if extra_sha256 {
+    let res = if extra_sha256 {
         base64url(&sha256(key_auth.as_bytes()))
     } else {
         key_auth
-    }
+    };
+    Ok(res)
 }
 
 fn wait_for_auth_status(
@@ -295,19 +296,17 @@ mod test {
         let server = crate::test::with_directory_server();
         let url = DirectoryUrl::Other(&server.dir_url);
         let dir = Directory::from_url(url)?;
-        let acc = dir.register_account(vec![
-            "mailto:foo@bar.com".to_string(),
-        ])?;
+        let acc = dir.register_account(vec!["mailto:foo@bar.com".to_string()])?;
         let ord = acc.new_order("acmetest.example.com", &[])?;
         let authz = ord.authorizations()?;
         assert!(authz.len() == 1);
         let auth = &authz[0];
         {
-            let http = auth.http_challenge();
+            let http = auth.http_challenge().unwrap();
             assert!(http.need_validate());
         }
         {
-            let dns = auth.dns_challenge();
+            let dns = auth.dns_challenge().unwrap();
             assert!(dns.need_validate());
         }
         Ok(())

--- a/src/order/mod.rs
+++ b/src/order/mod.rs
@@ -328,7 +328,7 @@ mod test {
         let ord = acc.new_order("acmetest.example.com", &[])?;
         // shortcut auth
         let ord = CsrOrder { order: ord.order };
-        let pkey = cert::create_p256_key().unwrap();
+        let pkey = cert::create_p256_key()?;
         let _ord = ord.finalize_pkey(pkey, 1)?;
         Ok(())
     }
@@ -343,13 +343,13 @@ mod test {
 
         // shortcut auth
         let ord = CsrOrder { order: ord.order };
-        let pkey = cert::create_p256_key().unwrap();
+        let pkey = cert::create_p256_key()?;
         let ord = ord.finalize_pkey(pkey, 1)?;
 
         let cert = ord.download_cert()?;
         assert_eq!("CERT HERE", cert.certificate());
         assert!(!cert.private_key().is_empty());
-        assert_eq!(cert.valid_days_left().unwrap(), 89);
+        assert_eq!(cert.valid_days_left()?, 89);
 
         Ok(())
     }


### PR DESCRIPTION
We would never want a crate to panic over a code that user have no control over. this PR removes all unwrapping.