### PR TITLE
`challenge.validate()` to not consume self and delay to be represented with `std::time::Duration`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Library for requesting certificates from an ACME provider (acme-l
 license = "MIT"
 repository = "https://github.com/kpcyrd/acme-micro"
 readme = "README.md"
-version = "0.9.0"
+version = "0.10.0"
 authors = [
     "Martin Algesten <martin@algesten.se>",
     "kpcyrd <git@rxv.cc>",
@@ -15,7 +15,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-base64 = "0.12"
+base64 = "0.13"
 lazy_static = "1.4"
 log = "0.4"
 openssl = "0.10"
@@ -26,7 +26,7 @@ ureq = "1"
 
 [dev-dependencies]
 doc-comment = "0.3"
-env_logger = { version = "0.7", default-features = false }
+env_logger = { version = "0.8", default-features = false }
 futures = "0.1.25"
 hyper = "0.12"
-regex = "1.3"
+regex = "1.4"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Uses ACME v2 to issue/renew certificates.
 ```rust
 use acme_micro::{Error, Certificate, Directory, DirectoryUrl};
 use acme_micro::create_p384_key;
+use std::time::Duration;
 
 fn request_cert() -> Result<Certificate, Error> {
 
@@ -78,7 +79,7 @@ let ord_csr = loop {
     // confirm ownership of the domain, or fail due to the
     // not finding the proof. To see the change, we poll
     // the API with 5000 milliseconds wait between.
-    chall.validate(5000)?;
+    chall.validate(Duration::from_millis(5000))?;
 
     // Update the state against the ACME API.
     ord_new.refresh()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 //! ```no_run
 //! use acme_micro::{Error, Certificate, Directory, DirectoryUrl};
 //! use acme_micro::create_p384_key;
+//! use std::time::Duration;
 //!
 //! fn request_cert() -> Result<Certificate, Error> {
 //!
@@ -76,7 +77,7 @@
 //!     // confirm ownership of the domain, or fail due to the
 //!     // not finding the proof. To see the change, we poll
 //!     // the API with 5000 milliseconds wait between.
-//!     chall.validate(5000)?;
+//!     chall.validate(Duration::from_millis(5000))?;
 //!
 //!     // Update the state against the ACME API.
 //!     ord_new.refresh()?;

--- a/src/order/auth.rs
+++ b/src/order/auth.rs
@@ -69,6 +69,7 @@ impl Auth {
     /// use acme_micro::Error;
     /// use std::fs::File;
     /// use std::io::Write;
+    /// use std::time::Duration;
     ///
     /// fn web_authorize(auth: &Auth) -> Result<(), Error> {
     ///   let challenge = auth.http_challenge().unwrap();
@@ -79,7 +80,7 @@ impl Auth {
     ///   };
     ///   let mut file = File::create(&path)?;
     ///   file.write_all(challenge.http_proof()?.as_bytes())?;
-    ///   challenge.validate(5000)?;
+    ///   challenge.validate(Duration::from_millis(5000))?;
     ///   Ok(())
     /// }
     /// ```
@@ -102,12 +103,13 @@ impl Auth {
     /// ```no_run
     /// use acme_micro::order::Auth;
     /// use acme_micro::Error;
+    /// use std::time::Duration;
     ///
     /// fn dns_authorize(auth: &Auth) -> Result<(), Error> {
     ///   let challenge = auth.dns_challenge().unwrap();
     ///   let record = format!("_acme-challenge.{}.", auth.domain_name());
     ///   // route_53_set_record(&record, "TXT", challenge.dns_proof());
-    ///   challenge.validate(5000)?;
+    ///   challenge.validate(Duration::from_millis(5000))?;
     ///   Ok(())
     /// }
     /// ```

--- a/src/order/mod.rs
+++ b/src/order/mod.rs
@@ -283,7 +283,7 @@ impl CertOrder {
             .order
             .api_order
             .certificate
-            .ok_or(anyhow::anyhow!("certificate url"))?;
+            .ok_or_else(|| anyhow::anyhow!("certificate url"))?;
         let inner = self.order.inner;
 
         let res = inner.transport.call(&url, &ApiEmptyString)?;

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -7,7 +7,7 @@ use std::net::TcpListener;
 use std::thread;
 
 lazy_static! {
-    static ref RE_URL: regex::Regex = { regex::Regex::new("<URL>").unwrap() };
+    static ref RE_URL: regex::Regex = regex::Regex::new("<URL>").unwrap();
 }
 
 pub struct TestServer {


### PR DESCRIPTION
I have updated the dependencies that don't break code. 
### changed 
- `challenge.validate()` to not be a self consuming method, as it can be useful to run in a loop while waiting for DNS TXT record changes to be reflected. 
- `challenge.validate()` to take `std::time::Duration` as delay. 