### PR TITLE
Expose ureq feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ keywords = ["letsencrypt", "acme"]
 categories = ["web-programming", "api-bindings"]
 edition = "2018"
 
+[features]
+native-certs = ["ureq/native-certs"]
+default = ["ureq/default"]
+
 [dependencies]
 anyhow = "1.0"
 base64 = "0.13"
@@ -22,7 +26,7 @@ openssl = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 time = "0.1"
-ureq = { version="1", features = ["native-certs"] }
+ureq = {version = "1.0", default-features = true }
 
 [dev-dependencies]
 doc-comment = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ openssl = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 time = "0.1"
-ureq = "1"
+ureq = { version="1", features = ["native-certs"] }
 
 [dev-dependencies]
 doc-comment = "0.3"


### PR DESCRIPTION
This is a tiny change, no actual code changes, just exposing the `ureq` feature flag `native-certs`. Its purpose is to enable the library to be used with `pebble` a local acme server. `Pebble` comes with its own `mini-ca` which has to be added to the local trusted store.