### PR TITLE
dependency updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ ureq = "1"
 
 [dev-dependencies]
 doc-comment = "0.3"
-env_logger = { version = "0.8", default-features = false }
+env_logger = { version = "0.10", default-features = false }
 futures = "0.1.25"
 hyper = "0.12"
 regex = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,9 @@ log = "0.4"
 openssl = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-time = "0.1"
+time = { version = "0.3", features = ["local-offset"] }
+time-fmt = "0.3"
+time-tz = "1"
 ureq = "1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-base64 = "0.13"
+base64 = "0.21"
 lazy_static = "1.4"
 log = "0.4"
 openssl = "0.10"

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,4 @@
+use base64::engine::Engine;
 use lazy_static::lazy_static;
 use serde::de::DeserializeOwned;
 
@@ -5,12 +6,12 @@ use crate::error::*;
 use crate::req::req_safe_read_body;
 
 lazy_static! {
-    static ref BASE64_CONFIG: base64::Config =
-        base64::Config::new(base64::CharacterSet::UrlSafe, false);
+    static ref BASE64_CONFIG: base64::engine::general_purpose::GeneralPurpose =
+        base64::engine::general_purpose::URL_SAFE;
 }
 
 pub(crate) fn base64url<T: ?Sized + AsRef<[u8]>>(input: &T) -> String {
-    base64::encode_config(input, *BASE64_CONFIG)
+    BASE64_CONFIG.encode(input)
 }
 
 pub(crate) fn read_json<T: DeserializeOwned>(res: ureq::Response) -> Result<T> {


### PR DESCRIPTION
Dependabot keeps bothering me about CVE-2020-26235, which affects the *time* crate in certain versions.
I took the *time* (heh) and updated to the 0.3 version which is not affected.
This may cause API changes, I'm not exactly sure, but IMHO the update is reasonable.

There are a few more dependencies which would like to see an update:

```console
% cargo outdated -R
Name     Project  Compat  Latest   Kind         Platform
----     -------  ------  ------   ----         --------
futures  0.1.31   ---     0.3.28   Development  ---
hyper    0.12.36  ---     0.14.26  Development  ---
ureq     1.5.5    ---     2.6.2    Normal       ---
```

However:

- *futures* and *hyper* are both just dev-dependencies, and updating them seems to be non-trivial (I tried, this one heads into async territory and requires to pull in *tokio* and whatnot)
- *ureq* changes a few signatures (fair enough, the version jump is significant), including adding result types natively which AFAICT are currently added by *acme-micro*, which is not trivial either

Either way the current set of changes bumps a few trivial ones and the *time* one which has an open CVE (however I suspect that this version of *ureq* might have undiscovered vulnerabilities too, however I'm more of a *reqwest* person myself which'd also have a blocking feature, but changing the entire http client library seems a little overkill).