### PR TITLE
Fix badNonce detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Library for requesting certificates from an ACME provider (acme-l
 license = "MIT"
 repository = "https://github.com/kpcyrd/acme-micro"
 readme = "README.md"
-version = "0.12.0"
+version = "0.12.0+frk.1"
 authors = [
     "Martin Algesten <martin@algesten.se>",
     "kpcyrd <git@rxv.cc>",
@@ -12,6 +12,8 @@ authors = [
 keywords = ["letsencrypt", "acme"]
 categories = ["web-programming", "api-bindings"]
 edition = "2018"
+
+publish = ["elleci"]
 
 [dependencies]
 anyhow = "1.0"

--- a/src/api.rs
+++ b/src/api.rs
@@ -45,7 +45,7 @@ pub struct ApiProblem {
 
 impl ApiProblem {
     pub fn is_bad_nonce(&self) -> bool {
-        self._type == "badNonce"
+        self._type == "urn:ietf:params:acme:error:badNonce"
     }
     pub fn is_jwt_verification_error(&self) -> bool {
         (self._type == "urn:acme:error:malformed"


### PR DESCRIPTION
Letsencrypt returns `urn:ietf:params:acme:error:badNonce` but library does a string comparison with `badNonce`